### PR TITLE
upgrade(claims): migrate early contributor claim

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1080,6 +1080,7 @@ func (app *Arcis) setupUpgradeHandlers() {
 			app.mm, app.configurator,
 			app.BankKeeper,
 			app.InflationKeeper,
+			app.ClaimsKeeper,
 		),
 	)
 

--- a/app/upgrades/v7/constants.go
+++ b/app/upgrades/v7/constants.go
@@ -4,14 +4,19 @@ const (
 	// UpgradeName is the shared upgrade plan name for mainnet and testnet
 	UpgradeName = "v7.0.0"
 	// TODO MainnetUpgradeHeight defines the Arcis mainnet block height on which the upgrade will take place
-	MainnetUpgradeHeight = 1_042_000
+	MainnetUpgradeHeight = 0
 	// TODO TestnetUpgradeHeight defines the Arcis testnet block height on which the upgrade will take place
-	TestnetUpgradeHeight = 2_176_500
+	TestnetUpgradeHeight = 0
 	// UpgradeInfo defines the binaries that will be used for the upgrade
-	UpgradeInfo = `'{"binaries":{"darwin/arm64":"https://github.com/Ambiplatforms-TORQUE/arcis/releases/download/v7.0.0/arcis_7.0.0_Darwin_arm64.tar.gz","darwin/x86_64":"https://github.com/arcis/arcis/releases/download/v7.0.0/arcis_7.0.0_Darwin_x86_64.tar.gz","linux/arm64":"https://github.com/arcis/arcis/releases/download/v7.0.0/arcis_7.0.0_Linux_arm64.tar.gz","linux/x86_64":"https://github.com/arcis/arcis/releases/download/v7.0.0/arcis_7.0.0_Linux_x86_64.tar.gz","windows/x86_64":"https://github.com/arcis/arcis/releases/download/v7.0.0/arcis_7.0.0_Windows_x86_64.zip"}}'`
+	UpgradeInfo = `'{"binaries":{"darwin/arm64":"https://github.com/Ambiplatforms-TORQUE/arcis/releases/download/v1.0.3/arcis_1.0.3_Darwin_arm64.tar.gz","darwin/x86_64":"https://github.com/arcis/arcis/releases/download/v1.0.3/arcis_1.0.3_Darwin_x86_64.tar.gz","linux/arm64":"https://github.com/arcis/arcis/releases/download/v1.0.3/arcis_1.0.3_Linux_arm64.tar.gz","linux/x86_64":"https://github.com/arcis/arcis/releases/download/v1.0.3/arcis_1.0.3_Linux_x86_64.tar.gz","windows/x86_64":"https://github.com/arcis/arcis/releases/download/v1.0.3/arcis_1.0.3_Windows_x86_64.zip"}}'`
 
 	// FaucetAddressFrom is the inaccessible secp address of the Testnet Faucet
 	FaucetAddressFrom = "arcis1z4ya98ga2xnffn2mhjym7tzlsm49ec23890sze"
 	// FaucetAddressTo is the new eth_secp address of the Testnet Faucet
 	FaucetAddressTo = "arcis1ujm4z5v9zkdqm70xnptr027gqu90f7lxjr0fch"
+
+	// ContributorAddrFrom is the lost address of an early contributor
+	ContributorAddrFrom = "arcis1659xwt0hnu5humgek7scefhnpcm2w6hyvy4fsq"
+	// ContributorAddrTo is the new address of an early contributor
+	ContributorAddrTo = "arcis1pktlmqrz448cuazl98tqmsj4kjwpqpmaa0cjcf"
 )

--- a/app/upgrades/v7/upgrades.go
+++ b/app/upgrades/v7/upgrades.go
@@ -8,6 +8,7 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/Ambiplatforms-TORQUE/arcis/v6/types"
+	claimskeeper "github.com/Ambiplatforms-TORQUE/arcis/v6/x/claims/keeper"
 	inflationkeeper "github.com/Ambiplatforms-TORQUE/arcis/v6/x/inflation/keeper"
 )
 
@@ -17,6 +18,7 @@ func CreateUpgradeHandler(
 	configurator module.Configurator,
 	bk bankkeeper.Keeper,
 	ik inflationkeeper.Keeper,
+	ck *claimskeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		logger := ctx.Logger().With("upgrade", UpgradeName)
@@ -35,6 +37,9 @@ func CreateUpgradeHandler(
 		if types.IsMainnet(ctx.ChainID()) {
 			logger.Debug("migrating skipped epochs value of inflation module...")
 			MigrateSkippedEpochs(ctx, ik)
+
+			logger.Debug("migrating early contributor's claim record to new address...")
+			MigrateContributorClaim(ctx, ck)
 		}
 
 		// Leave modules are as-is to avoid running InitGenesis.
@@ -75,4 +80,19 @@ func MigrateSkippedEpochs(ctx sdk.Context, ik inflationkeeper.Keeper) {
 	previousValue := ik.GetSkippedEpochs(ctx)
 	newValue := previousValue - uint64(2)
 	ik.SetSkippedEpochs(ctx, newValue)
+}
+
+// MigrateContributorClaim migrates the claims record of a specific early
+// contributor from one address to another
+func MigrateContributorClaim(ctx sdk.Context, k *claimskeeper.Keeper) {
+	from, _ := sdk.AccAddressFromBech32(ContributorAddrFrom)
+	to, _ := sdk.AccAddressFromBech32(ContributorAddrTo)
+
+	cr, found := k.GetClaimsRecord(ctx, from)
+	if !found {
+		return
+	}
+
+	k.DeleteClaimsRecord(ctx, from)
+	k.SetClaimsRecord(ctx, to, cr)
 }

--- a/app/upgrades/v7/upgrades_test.go
+++ b/app/upgrades/v7/upgrades_test.go
@@ -21,6 +21,7 @@ import (
 	v7 "github.com/Ambiplatforms-TORQUE/arcis/v6/app/upgrades/v7"
 	"github.com/Ambiplatforms-TORQUE/arcis/v6/testutil"
 	arcistypes "github.com/Ambiplatforms-TORQUE/arcis/v6/types"
+	claimstypes "github.com/Ambiplatforms-TORQUE/arcis/v6/x/claims/types"
 )
 
 type UpgradeTestSuite struct {
@@ -148,6 +149,53 @@ func (suite *UpgradeTestSuite) TestMigrateSkippedEpochs() {
 
 			newSkippedEpochs := suite.app.InflationKeeper.GetSkippedEpochs(suite.ctx)
 			suite.Require().Equal(tc.expectedSkippedEpochs, newSkippedEpochs)
+		})
+	}
+}
+
+func (suite *UpgradeTestSuite) TestMigrateClaim() {
+	from, err := sdk.AccAddressFromBech32(v7.ContributorAddrFrom)
+	suite.Require().NoError(err)
+	to, err := sdk.AccAddressFromBech32(v7.ContributorAddrTo)
+	suite.Require().NoError(err)
+	cr := claimstypes.ClaimsRecord{InitialClaimableAmount: sdk.NewInt(100), ActionsCompleted: []bool{false, false, false, false}}
+
+	testCases := []struct {
+		name     string
+		malleate func()
+		expPass  bool
+	}{
+		{
+			"with claims record",
+			func() {
+				suite.app.ClaimsKeeper.SetClaimsRecord(suite.ctx, from, cr)
+			},
+			true,
+		},
+		{
+			"without claims record",
+			func() {
+			},
+			false,
+		},
+	}
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.SetupTest(arcistypes.TestnetChainID + "-2") // reset
+
+			tc.malleate()
+
+			v7.MigrateContributorClaim(suite.ctx, suite.app.ClaimsKeeper)
+
+			_, foundFrom := suite.app.ClaimsKeeper.GetClaimsRecord(suite.ctx, from)
+			crTo, foundTo := suite.app.ClaimsKeeper.GetClaimsRecord(suite.ctx, to)
+			if tc.expPass {
+				suite.Require().False(foundFrom)
+				suite.Require().True(foundTo)
+				suite.Require().Equal(crTo, cr)
+			} else {
+				suite.Require().False(foundTo)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adding relevant claims module code to v7.


______

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [X] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] targeted the correct branch (see [PR Targeting](https://github.com/Ambiplatforms-TORQUE/arcis/blob/main/CONTRIBUTING.md#pr-targeting))
- [X] provided a link in the PR description to the relevant issue or specification
- [X] reviewed "Files changed" and left comments if necessary
- [X] confirmed all required CI checks have passed

Code maintenance:

I have...

- [X] written unit and integration [tests](https://github.com/Ambiplatforms-TORQUE/arcis/blob/main/CONTRIBUTING.md#testing)
- [X] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [X] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items.

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed all author checklist items have been addressed
- [x] confirmed that this PR does not change production code
